### PR TITLE
Fix version file URL properties

### DIFF
--- a/LPR.version
+++ b/LPR.version
@@ -1,7 +1,7 @@
 {
   "NAME"     : "LagrangeProjectRSS",
   "DOWNLOAD" : "https://github.com/dongk99/LagrangeProjectRSS/releases",
-  "URL"      : "https://raw.githubusercontent.com/LagrangeProjectRSS/master/GameData/LagrangeProjectRSS/LPR.version",
+  "URL"      : "https://raw.githubusercontent.com/dongk99/LagrangeProjectRSS/refs/heads/main/LagrangeProjectRSS/LPR.version",
   "GITHUB" : {
     "USERNAME"   : "dongk99",
     "REPOSITORY" : "LagrangeProjectRSS"

--- a/LPR.version
+++ b/LPR.version
@@ -1,7 +1,7 @@
 {
   "NAME"     : "LagrangeProjectRSS",
   "DOWNLOAD" : "https://github.com/dongk99/LagrangeProjectRSS/releases",
-  "URL"      : "https://raw.githubusercontent.com/dongk99/LagrangeProjectRSS/refs/heads/main/LagrangeProjectRSS/LPR.version",
+  "URL"      : "https://raw.githubusercontent.com/dongk99/LagrangeProjectRSS/main/LagrangeProjectRSS/LPR.version",
   "GITHUB" : {
     "USERNAME"   : "dongk99",
     "REPOSITORY" : "LagrangeProjectRSS"

--- a/LagrangeProjectRSS/LPR.version
+++ b/LagrangeProjectRSS/LPR.version
@@ -1,7 +1,7 @@
 {
   "NAME"     : "LagrangeProjectRSS",
   "DOWNLOAD" : "https://github.com/dongk99/LagrangeProjectRSS/releases",
-  "URL"      : "https://raw.githubusercontent.com/LagrangeProjectRSS/master/GameData/LagrangeProjectRSS/LPR.version",
+  "URL"      : "https://raw.githubusercontent.com/dongk99/LagrangeProjectRSS/refs/heads/main/LagrangeProjectRSS/LPR.version",
   "GITHUB" : {
     "USERNAME"   : "dongk99",
     "REPOSITORY" : "LagrangeProjectRSS"

--- a/LagrangeProjectRSS/LPR.version
+++ b/LagrangeProjectRSS/LPR.version
@@ -1,7 +1,7 @@
 {
   "NAME"     : "LagrangeProjectRSS",
   "DOWNLOAD" : "https://github.com/dongk99/LagrangeProjectRSS/releases",
-  "URL"      : "https://raw.githubusercontent.com/dongk99/LagrangeProjectRSS/refs/heads/main/LagrangeProjectRSS/LPR.version",
+  "URL"      : "https://raw.githubusercontent.com/dongk99/LagrangeProjectRSS/main/LagrangeProjectRSS/LPR.version",
   "GITHUB" : {
     "USERNAME"   : "dongk99",
     "REPOSITORY" : "LagrangeProjectRSS"


### PR DESCRIPTION
Hi @dongk99, the version files have a broken URL in their `URL` fields.
These changes fix it (after you make a new release).
Noticed while reviewing KSP-CKAN/NetKAN#10323.